### PR TITLE
ignore some problems based on path

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.dgknght/app-lib "0.3.14"
+(defproject com.github.dgknght/app-lib "0.3.15"
   :description "Library of commonly used functions for web app development"
   :url "https://github.com/dgknght/app-lib"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/clj/dgknght/app_lib/validation.clj
+++ b/src/clj/dgknght/app_lib/validation.clj
@@ -2,6 +2,7 @@
   (:refer-clojure :exclude [format])
   (:require [clojure.core :as c]
             [clojure.spec.alpha :as s]
+            [clojure.pprint :refer [pprint]]
             [dgknght.app-lib.web :refer [email-pattern] ]
             [dgknght.app-lib.inflection :refer [humanize
                                                 conjoin]])
@@ -212,9 +213,11 @@
 
 (defn- ->errors
   [{::s/keys [problems]}]
-  (reduce append-error
-          {}
-          problems))
+  (->> problems
+       (remove #(= ::s/nil ; this can cause problems with nested maps and I don't think it ever expresses meaningful information
+                   (last (:path %))))
+       (reduce append-error
+               {})))
 
 (defn validate
   "Validates the specified model using the specified spec"


### PR DESCRIPTION
I found this spec:
```clojure
(s/def :entity/settings (s/nilable
                          (s/keys :opt [:settings/inventory-method
                                        :settings/monitored-account-ids
                                        :settings/default-commodity-id])))
```
can cause this failure:
```clojure
({:path [:entity/settings
         :clojure.spec.alpha/nil],
        :pred nil?,
        :val #:settings{:inventory-method :not-valid},
        :via [:clj-money.models.entities/entity
              :entity/settings],
        :in [:entity/settings]}
 {:path [:entity/settings
         :clojure.spec.alpha/pred
         :settings/inventory-method],
  :pred #{:fifo :lifo},
  :val :not-valid,
  :via [:clj-money.models.entities/entity
        :entity/settings
        :settings/inventory-method],
  :in [:entity/settings
       :settings/inventory-method]})
```
When translating the problems above into a map like
```clojure
{:entity/settings {:settings/inventory-method ["Inventory method must be fifo or lifo"]}}
```
The 1st error puts a vector at key `:entity/settings` while the second expects that value at `:entity/settings` to be a map. Ignoring the 1st solves the problem and produces the expected validation error map.