### PR TITLE
fix bug setting class on nav tab

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.dgknght/app-lib "0.3.24"
+(defproject com.github.dgknght/app-lib "0.3.25"
   :description "Library of commonly used functions for web app development"
   :url "https://github.com/dgknght/app-lib"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/cljs/dgknght/app_lib/bootstrap_5.cljs
+++ b/src/cljs/dgknght/app_lib/bootstrap_5.cljs
@@ -64,6 +64,17 @@
                       #(assoc % :in-dropdown? true)))
            doall)]]))
 
+(defn- merge-attr
+  "Merge the given maps. If the values is sequential, combine them,
+  otherwise the later value wins."
+  [& ms]
+  (apply merge-with
+         (fn [v1 v2]
+           (if (sequential? v1)
+             (into v1 v2)
+             v2))
+         ms))
+
 (defmethod ^:private nav-item :default
   [{:keys [id label path tool-tip active? nav-fn badge-class badge toggle in-dropdown?]
     :or {path "#"}}]
@@ -72,13 +83,13 @@
   [:li {:class (when-not in-dropdown? "nav-item") }
    [:a.d-flex.align-items-center
     (cond-> {:href path
-             :class (if in-dropdown? "dropdown-item" "nav-link")}
+             :class [(if in-dropdown? "dropdown-item" "nav-link")]}
       tool-tip (assoc :title tool-tip)
       toggle (merge {:data-bs-toggle :collapse
                      :data-bs-target toggle})
       nav-fn (assoc :on-click nav-fn)
-      active? (assoc :class "active"
-                     :aria-current "page"))
+      active? (merge-attr {:class ["active"]
+                          :aria-current "page"}))
     (or label (title-case id))
     (when badge
       [:span.badge.ms-1 {:class badge-class} badge])]])


### PR DESCRIPTION
The `active` class is overwriting the `nav-link` class. Adjust the logic to combine classes instead of replacing.