### PR TITLE
better http redirect assertion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ This matters for any date/time or number formatting tests.
 ## Guidelines
 
 - Write tests first
+  - Focus on behavior, not implementation
 - Fix any failing tests
 - Fix any linter errors (For now allow deprecation warnings about
   dgknght.app-lib.bootstrap-cons until we've removed all references from projects

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.dgknght/app-lib "0.3.44-SNAPSHOT"
+(defproject com.github.dgknght/app-lib "0.3.44"
   :description "Library of commonly used functions for web app development"
   :url "https://github.com/dgknght/app-lib"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.github.dgknght/app-lib "0.3.43"
+(defproject com.github.dgknght/app-lib "0.3.44-SNAPSHOT"
   :description "Library of commonly used functions for web app development"
   :url "https://github.com/dgknght/app-lib"
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"

--- a/src/cljc/dgknght/app_lib/core.cljc
+++ b/src/cljc/dgknght/app_lib/core.cljc
@@ -295,3 +295,8 @@
   (if (empty? ks)
     (dissoc m k)
     (update-in m [k] dissoc-in ks)))
+
+(defn pattern?
+  [x]
+  #?(:clj (instance? java.util.regex.Pattern x)
+     :cljs (instance? js/RegExp x)))

--- a/src/cljc/dgknght/app_lib/test_assertions/impl.cljc
+++ b/src/cljc/dgknght/app_lib/test_assertions/impl.cljc
@@ -205,13 +205,18 @@
                 {:type :pass :message ~msg}
                 {:type :fail :message (report-msg ~msg "Didn't find the expected error message")})))))
 
+(defn- pattern?
+  [x]
+  #?(:clj (instance? java.util.regex.Pattern x)
+     :cljs (instance? js/RegExp x)))
+
 (defn http-redirect-to?
   [msg form]
   (let [target (safe-nth form 1)
         res (safe-nth form 2)]
     `(let [res# ~res
            location# (get-in res# [:headers "Location"])]
-       (assert (or (string? ~target) (instance? #?(:clj java.util.regex.Pattern :cljs js/RegExp) ~target))
+       (assert ((some-fn string? pattern?) ~target)
                (str "The first agument must be a url string or regular expression. Found: " (prn-str ~target)))
        (assert (map? res#) (str "The second argument must be a response map. Found: " (prn-str res#)))
        (if (= 302 (:status res#))

--- a/src/cljc/dgknght/app_lib/test_assertions/impl.cljc
+++ b/src/cljc/dgknght/app_lib/test_assertions/impl.cljc
@@ -20,7 +20,8 @@
             [dgknght.app-lib.models :as models]
             [dgknght.app-lib.core :refer [update-in-if
                                           prune-to
-                                          safe-nth]])
+                                          safe-nth
+                                          pattern?]])
   #?(:clj (:import [java.io StringWriter InputStream])))
 
 #?(:cljs (def fmt goog.string/format)
@@ -204,11 +205,6 @@
               (if pass?#
                 {:type :pass :message ~msg}
                 {:type :fail :message (report-msg ~msg "Didn't find the expected error message")})))))
-
-(defn- pattern?
-  [x]
-  #?(:clj (instance? java.util.regex.Pattern x)
-     :cljs (instance? js/RegExp x)))
 
 (defn http-redirect-to?
   [msg form]

--- a/src/cljc/dgknght/app_lib/test_assertions/impl.cljc
+++ b/src/cljc/dgknght/app_lib/test_assertions/impl.cljc
@@ -209,20 +209,23 @@
   [msg form]
   (let [target (safe-nth form 1)
         res (safe-nth form 2)]
-    `(let [res# ~res]
-       (assert (string? ~target) (str "The first agument must be a url. Found: " (prn-str ~target)))
+    `(let [res# ~res
+           location# (get-in res# [:headers "Location"])]
+       (assert (or (string? ~target) (instance? #?(:clj java.util.regex.Pattern :cljs js/RegExp) ~target))
+               (str "The first agument must be a url string or regular expression. Found: " (prn-str ~target)))
        (assert (map? res#) (str "The second argument must be a response map. Found: " (prn-str res#)))
        (if (= 302 (:status res#))
-         (if (= ~target
-                (get-in res# [:headers "Location"]))
+         (if (if (string? ~target)
+               (= ~target location#)
+               (re-find ~target location#))
            {:type :pass
             :message ~msg
             :expected ~target
-            :actual (get-in res# [:headers "Location"])}
+            :actual location#}
            {:type :fail
             :message (fmt "Expected response to redirect to %s, but it didn't" ~target)
             :expected ~target
-            :actual (get-in res# [:headers "Location"])})
+            :actual location#})
          {:type :fail
           :message "Expected response to be a redirect, but it wasn't"
           :expected 302

--- a/test/dgknght/app_lib/core_test.clj
+++ b/test/dgknght/app_lib/core_test.clj
@@ -268,3 +268,7 @@
          (lib/dissoc-in {:one 1
                          :two 2}
                         [:two]))))
+
+(deftest identify-a-regex-pattern
+  (is (lib/pattern? #"^pattern$"))
+  (is (not (lib/pattern? "not a pattern"))))

--- a/test/dgknght/app_lib/core_test.cljs
+++ b/test/dgknght/app_lib/core_test.cljs
@@ -257,3 +257,7 @@
          (lib/dissoc-in {:one 1
                          :two 2}
                         [:two]))))
+
+(deftest identify-a-regex-pattern
+  (is (lib/pattern? #"^pattern$"))
+  (is (not (lib/pattern? "not a pattern"))))

--- a/test/dgknght/app_lib/test_assertions_test.clj
+++ b/test/dgknght/app_lib/test_assertions_test.clj
@@ -78,7 +78,12 @@
         "https://mysite.com/over-here"
         {:status 302
          :headers {"Location" "https://mysite.com/over-here"}})
-      "Status 302 is a redirect"))
+      "Status 302 is a redirect")
+  (is (http-redirect-to?
+        #"over-here$"
+        {:status 302
+         :headers {"Location" "https://mysite.com/over-here"}})
+      "A regular expression can be used to match the redirect location"))
 
 (deftest assert-an-http-response-indicates-bad-request
   (is (http-bad-request? {:status 400})

--- a/test/dgknght/app_lib/test_assertions_test.cljs
+++ b/test/dgknght/app_lib/test_assertions_test.cljs
@@ -1,5 +1,5 @@
 (ns dgknght.app-lib.test-assertions-test
-  (:require [cljs.test :refer [deftest is]]
+  (:require [cljs.test :refer [deftest is testing]]
             [cljs-time.core :as t]
             [dgknght.app-lib.test-assertions]))
 
@@ -86,16 +86,17 @@
       "Status 204 is no content"))
 
 (deftest assert-an-http-response-is-a-redirect
-  (is (dgknght.app-lib.test-assertions/http-redirect-to?
-        "https://mysite.com/over-here"
-        {:status 302
-         :headers {"Location" "https://mysite.com/over-here"}})
-      "Status 302 is a redirect")
-  (is (dgknght.app-lib.test-assertions/http-redirect-to?
-        #"over-here$"
-        {:status 302
-         :headers {"Location" "https://mysite.com/over-here"}})
-      "A regular expression can be used to match the redirect location"))
+  (testing "an exact match"
+    (is (dgknght.app-lib.test-assertions/http-redirect-to?
+          "https://mysite.com/over-here"
+          {:status 302
+           :headers {"Location" "https://mysite.com/over-here"}})
+        "Status 302 is a redirect"))
+  (testing "a pattern match"
+    (is (dgknght.app-lib.test-assertions/http-redirect-to?
+          #"over-here$"
+          {:status 302
+           :headers {"Location" "https://mysite.com/over-here"}}))))
 
 (deftest assert-an-http-response-indicates-bad-request
   (is (dgknght.app-lib.test-assertions/http-bad-request?

--- a/test/dgknght/app_lib/test_assertions_test.cljs
+++ b/test/dgknght/app_lib/test_assertions_test.cljs
@@ -90,7 +90,12 @@
         "https://mysite.com/over-here"
         {:status 302
          :headers {"Location" "https://mysite.com/over-here"}})
-      "Status 302 is a redirect"))
+      "Status 302 is a redirect")
+  (is (dgknght.app-lib.test-assertions/http-redirect-to?
+        #"over-here$"
+        {:status 302
+         :headers {"Location" "https://mysite.com/over-here"}})
+      "A regular expression can be used to match the redirect location"))
 
 (deftest assert-an-http-response-indicates-bad-request
   (is (dgknght.app-lib.test-assertions/http-bad-request?


### PR DESCRIPTION
Allow regular expression as alternative to exact string.

Also include the claude bits.